### PR TITLE
Fix license mismatch

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,9 @@
+Product List App License
+=======================
+
+This project is released under the terms of the GNU General Public License,
+version 3.0. The full license text follows below.
+
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/README.md
+++ b/README.md
@@ -81,4 +81,5 @@ npx uri-scheme open "productapp://product/1" --android
 
 ## License
 
-This project is licensed under the MIT License.
+This project is licensed under the terms of the **GNU General Public License v3.0**.
+See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- clarify GPL license in README
- add project header to LICENSE file

## Testing
- `yarn test` *(fails: package not present in lockfile)*
- `yarn install` *(fails: RequestError 403)*

------
https://chatgpt.com/codex/tasks/task_e_6849876330908331b0fb01439266023a