### PR TITLE
Add tests for Home filter/sort flow

### DIFF
--- a/__mocks__/@shopify/flash-list.js
+++ b/__mocks__/@shopify/flash-list.js
@@ -1,0 +1,4 @@
+const React = require('react');
+const { View } = require('react-native');
+const FlashList = React.forwardRef((props, ref) => <View ref={ref} {...props} />);
+module.exports = { FlashList };

--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/__mocks__/react-native-dropdown-picker.js
+++ b/__mocks__/react-native-dropdown-picker.js
@@ -1,0 +1,7 @@
+const React = require('react');
+const { View } = require('react-native');
+function DropDownPicker(props) {
+  return <View {...props} />;
+}
+module.exports = DropDownPicker;
+module.exports.default = DropDownPicker;

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -6,8 +6,12 @@ import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 import App from '../src/App';
 
+jest.useFakeTimers();
+
 test('renders correctly', async () => {
   await ReactTestRenderer.act(() => {
-    ReactTestRenderer.create(<App />);
+    const tree = ReactTestRenderer.create(<App />);
+    tree.unmount();
   });
+  jest.runOnlyPendingTimers();
 });

--- a/__tests__/CalendarModule.test.tsx
+++ b/__tests__/CalendarModule.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import ProductPage from '../src/pages/Product';
+import * as service from '../src/services';
+import { NativeModules } from 'react-native';
+
+jest.mock('../src/services');
+
+const mockRoute = { params: { itemId: 1 } } as any;
+const mockNavigation = {} as any;
+
+describe('Calendar module', () => {
+  it('calls addEvent when pressing reminder button', async () => {
+    (service.getProductsItem as jest.Mock).mockResolvedValue({
+      id: 1,
+      title: 'Title',
+      price: 10,
+      rating: 4,
+      thumbnail: 'img',
+      description: 'desc',
+      brand: 'brand',
+      stock: '1',
+    });
+
+    NativeModules.CalendarModule = { addEvent: jest.fn() };
+
+    const { findByTestId } = render(
+      <ProductPage route={mockRoute} navigation={mockNavigation} />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const button = await findByTestId('create-reminder-button');
+
+    fireEvent.press(button);
+    expect(NativeModules.CalendarModule.addEvent).toHaveBeenCalled();
+  });
+});

--- a/__tests__/Home.test.tsx
+++ b/__tests__/Home.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import Home from '../src/pages/Home';
+import * as service from '../src/services';
+
+jest.mock('../src/services');
+
+const mockNavigation = { navigate: jest.fn() } as any;
+
+describe('Home filtering and sorting', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('changes category and sort state', async () => {
+    const getProducts = service.getProducts as jest.Mock;
+    const getCategories = service.getCategories as jest.Mock;
+
+    getProducts.mockResolvedValue([]);
+    getCategories.mockResolvedValue([
+      { slug: 'cat', name: 'Category', url: 'caturl' },
+    ]);
+
+    const { getByTestId } = render(<Home navigation={mockNavigation} />);
+
+    await waitFor(() => expect(getProducts).toHaveBeenCalled());
+
+    const dropdown = getByTestId('dropDownPicker');
+    fireEvent(dropdown, 'setValue', 'caturl');
+    fireEvent(dropdown, 'onSelectItem', { label: 'Category', value: 'caturl' });
+
+    expect(dropdown.props.value).toBe('caturl');
+
+    const sortButton = getByTestId('sort-button-0');
+    fireEvent.press(sortButton);
+    await waitFor(() => expect(sortButton.props.active).toBe(true));
+  });
+});

--- a/__tests__/ProductItem.test.tsx
+++ b/__tests__/ProductItem.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import ProductItem from '../src/components/ProductItem';
+
+test('renders information and handles press', () => {
+  const onPress = jest.fn();
+
+  const { getByText } = render(
+    <ProductItem
+      title="Item"
+      price={9.99}
+      rating={4}
+      thumbnail="img.jpg"
+      action={onPress}
+    />
+  );
+
+  fireEvent.press(getByText('Item').parent!);
+  expect(onPress).toHaveBeenCalled();
+  expect(getByText('Item')).toBeTruthy();
+  expect(getByText('$ 9.99')).toBeTruthy();
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,10 @@
 module.exports = {
   preset: 'react-native',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(react-native|@react-native|@react-navigation|react-native-dropdown-picker)/)',
+  ],
+  moduleNameMapper: {
+    '\\.(png|jpg|jpeg|svg)$': '<rootDir>/__mocks__/fileMock.js',
+  },
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,11 @@
+import '@testing-library/jest-native/extend-expect';
+
+jest.useFakeTimers();
+
+jest.mock('@react-native-vector-icons/fontawesome6', () => 'FontAwesome6');
+
+jest.mock('@notifee/react-native', () => ({
+  createChannel: jest.fn(),
+  displayNotification: jest.fn(),
+  requestPermission: jest.fn(() => Promise.resolve(true)),
+}));

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "@react-native/eslint-config": "0.78.1",
     "@react-native/metro-config": "0.78.1",
     "@react-native/typescript-config": "0.78.1",
+    "@testing-library/jest-native": "^5.4.3",
+    "@testing-library/react-native": "^13.2.0",
     "@types/jest": "^29.5.13",
     "@types/react": "^19.0.0",
     "@types/react-test-renderer": "^19.0.0",

--- a/src/components/SortButton/index.tsx
+++ b/src/components/SortButton/index.tsx
@@ -2,9 +2,17 @@ import { Text } from 'react-native';
 import * as S from './styles';
 import FontAwesome6 from '@react-native-vector-icons/fontawesome6';
 
-const SortButton: React.FC = ({ name, icon, active, action }) => {
+interface SortButtonProps {
+  name: string;
+  icon: string;
+  active: boolean;
+  action: () => void;
+  testID?: string;
+}
+
+const SortButton: React.FC<SortButtonProps> = ({ name, icon, active, action, testID }) => {
   return (
-    <S.Container onPress={action} active={active}>
+    <S.Container onPress={action} active={active} testID={testID}>
       <Text>{name}</Text>
       <FontAwesome6 name={icon} iconStyle="solid" />
     </S.Container>

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -131,6 +131,7 @@ const Home: React.FC = ({ navigation }) => {
         setOpen={setCategoryOpen}
         setValue={setSelectedCategory}
         onSelectItem={setSelectedCategoryItem}
+        testID="dropDownPicker"
       />
       <S.Subtitles>Sort:</S.Subtitles>
       <S.SortList>
@@ -142,6 +143,7 @@ const Home: React.FC = ({ navigation }) => {
               icon={icon}
               active={active}
               action={() => sortAction(index)}
+              testID={`sort-button-${index}`}
             />
           );
         })}

--- a/src/pages/Product/index.tsx
+++ b/src/pages/Product/index.tsx
@@ -59,7 +59,7 @@ const Home: React.FC = ({ route }) => {
           <S.Label>Description: <S.Value>{productItem.description}</S.Value></S.Label>
           <S.Label>Stock: <S.Value>{productItem.stock}</S.Value></S.Label>
         </S.Body>
-        <S.Footer onPress={addEventToCalendar}>
+        <S.Footer onPress={addEventToCalendar} testID="create-reminder-button">
           <S.Label>Create a reminder</S.Label>
           <FontAwesome6 name="bell" iconStyle="solid" />
         </S.Footer>


### PR DESCRIPTION
## Summary
- configure Jest for React Native tests and add setup mocks
- expose testIDs in Home page and SortButton
- expose testID for calendar button on Product page
- add tests for ProductItem component
- add tests for Home page filter/sort behavior
- add tests for calendar native module

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6849943a82b8833196d881a98de833fd